### PR TITLE
Consensus checks

### DIFF
--- a/source/RunServer.py
+++ b/source/RunServer.py
@@ -4,14 +4,11 @@ import threading
 from time import sleep
 from server.GameServer import GameServer
 
-Waiting_For_Start = True
 Waiting_For_End = True
 
 def CommandLineTransitions():
     """This waits on input for game start and end"""
     global Waiting_For_Start, Waiting_For_End
-    temp = input("Press enter when all players are connected to start the game\n")
-    Waiting_For_Start = False
     temp = input("Press enter to end the game when finsihed playing\n")
     Waiting_For_End = False
 
@@ -25,12 +22,6 @@ def RunServer():
     global Waiting_For_Start, Waiting_For_End
     inputThread = threading.Thread(target=CommandLineTransitions)
     inputThread.start()
-    # wait for game to start
-    while Waiting_For_Start:
-        server.Pump()
-        sleep(0.0001)
-    #set active_game to true and run loop until game is over
-    server.startGame()
     while Waiting_For_End:
         server.Pump()
         sleep(0.0001)

--- a/source/client/ClientState.py
+++ b/source/client/ClientState.py
@@ -21,12 +21,8 @@ class ClientState():
         #Turn phase handled by controller
         self.turn_phase = 'inactive' #hard coded start phase as 'not my turn'
         self.round = -1 #Start with the 'no current round value
-        self.went_out = False #Boolean to track if you went out.
         self.name = "guest"
-        self.hand_list = []
-        self.hand_cards = []
-        self.played_cards = {}
-        self.discard_info = [None, 0] #This is top_card and then size
+        self.reset() #Start with state cleared for a fresh round
 
     def dealtHands(self, hands):
         """Store the extra hands dealt to player for use after first hand is cleared"""
@@ -48,21 +44,21 @@ class ClientState():
         return self.rules.goneOut(self.played_cards)
 
     def scoreRound(self):
-        """Get score for round and clears round specific state in preparation for next round to start"""
+        """Get score for round"""
         # Need to combine hand an foot for cancellation with played cards
         unplayed_cards = self.hand_cards
         for hand in self.hand_list:
             unplayed_cards += hand
         score = self.rules.scoreRound(self.played_cards, unplayed_cards, self.went_out)
-        
-        # Clear out round-specific state.
+        return score
+
+    def reset(self):
+        """Clear out round specific state to prepare for next round to start"""
         self.hand_list = []
         self.hand_cards = []
         self.played_cards = {}
         self.went_out = False
         self.discard_info = [None, 0]
-        
-        return score
         
     def newCards(self, card_list):
         """Update the cards in hand"""

--- a/source/client/Controller.py
+++ b/source/client/Controller.py
@@ -27,6 +27,11 @@ class Controller(ConnectionListener):
         self._state.name = displayName
         connection.Send({"action": "displayName", "name": displayName})
 
+    def setReady(self, readyState):
+        """Update the player's ready state with the server"""
+        self.ready = readyState
+        connection.Send({"action": "ready", "state": self.ready})
+
     def discard(self, discard_list):
         """Send discard to server"""
         if self._state.turn_phase != Turn_Phases[3]:
@@ -157,10 +162,16 @@ class Controller(ConnectionListener):
                 self._state.turn_phase = Turn_Phases[0]
                 connection.Send({"action": "discard", "cards": []})
             return False
-        
+    
+    
+    ### Fetchers for handView ###
     def getName(self):
         """return player name for labeling"""
         return self._state.name
+    
+    def isReady(self):
+        """return if the player is currently ready to move on"""
+        return self.ready
 
     def getHand(self):
         """sends _state to UI"""

--- a/source/client/Controller.py
+++ b/source/client/Controller.py
@@ -1,6 +1,7 @@
 from common.Card import Card
 
 from PodSixNet.Connection import connection, ConnectionListener
+from builtins import False
 
 Turn_Phases = ['inactive', 'draw', 'forcedAction', 'play']
 
@@ -263,4 +264,8 @@ class Controller(ConnectionListener):
         self.note = "{0} has gone out to end the round!".format(out_player)
         self._state.round = -1
         score = self._state.scoreRound()
+        self._state.reset()
         connection.Send({"action": "reportScore", "score": score})
+    
+    def Network_clearReady(self, data):
+        self.setReady(False)

--- a/source/client/HandView.py
+++ b/source/client/HandView.py
@@ -100,7 +100,8 @@ class HandView:
                     self.hand_info.sort(key=lambda wc: wc.key)
                     self.hand_info = self.refreshXY(self.hand_info)
                 elif self.ready_btn.isOver(pos):
-                    print('clicked on ready button')
+                    tempReady = self.controller.isReady()
+                    self.controller.setReady(not tempReady) #want to eventually make this a checkbox so I won't have to do this check not thing
                 elif self.mv_selected_btn.isOver(pos):
                     self.hand_info.sort(
                         key=lambda wc: (wc.img_clickable.x + (wc.status * UIC.Disp_Width))

--- a/source/client/TableView.py
+++ b/source/client/TableView.py
@@ -133,8 +133,3 @@ class TableView(ConnectionListener):
         for idx in range(len(self.player_names)):
             print("{0} scored {1} this round, and has {2} total".format(self.player_names[idx], round_scores[idx], total_scores[idx]))
         
-        #Clear out round specific status for next round to start later
-        #When we set up consensus method and in window scoring we might want to clear these out later
-        self.visible_cards = []
-        self.hand_status = []
-        self.playerByPlayer()

--- a/source/server/GameServer.py
+++ b/source/server/GameServer.py
@@ -23,20 +23,15 @@ class GameServer(Server, ServerState):
             channel.Send({"action": "connectionDenied"})
         else:
             self.players.append(channel)
-            self.Send_turnOrder()
+            self.Send_publicInfo()
             print(channel, "Client connected")
-
-    def startGame(self):
-        if len(self.players) == 0:
-            raise Exception("Can't start a game with no players")
-        self.nextRound()
-        self.nextTurn()
 
     def checkReady(self):
         """Confirm if all players are ready to move on to next round"""
         player_states = [p.ready for p in self.players]
         if False not in player_states:
             self.nextRound()
+            self.Send_broadcast({"action":"clearReady"}) #Reset in preparation for next round end
 
     def nextRound(self):
         """Start the next round of play"""
@@ -66,11 +61,6 @@ class GameServer(Server, ServerState):
     def Send_broadcast(self, data):
         """Send data to every connected player"""
         [p.Send(data) for p in self.players]
-
-    def Send_turnOrder(self):
-        """Adds a player to the end of the turn order"""
-        self.Send_broadcast({"action": "turnOrder", "players": [p.name for p in self.players]})
-        self.Send_publicInfo() #Currently a test ot see if we can remove the explicit turn order message and just use a stripped down public info
 
     def Send_endRound(self, player_name):
         """Notifies players that player_name has gone out and the round is over"""

--- a/source/server/PlayerChannel.py
+++ b/source/server/PlayerChannel.py
@@ -13,6 +13,7 @@ class PlayerChannel(Channel):
         self.visible_cards = {}
         self.hand_status = [] #order of information in this is specified by the ruleset
         self.scores = []
+        self.ready = False #for consensus transitions
         Channel.__init__(self, *args, **kwargs)
 
     def scoreForRound(self, round):

--- a/source/server/PlayerChannel.py
+++ b/source/server/PlayerChannel.py
@@ -50,11 +50,11 @@ class PlayerChannel(Channel):
     def Network_displayName(self, data):
         """Player submitted their display name"""
         self.name = data['name']
-        self._server.Send_turnOrder()
+        self._server.Send_publicInfo()
 
     def Network_ready(self, data):
         """Player changed their ready state"""
-        self.ready = data['ready']
+        self.ready = data['state']
         self._server.checkReady()
 
     ### Player Game Actions ###

--- a/source/server/PlayerChannel.py
+++ b/source/server/PlayerChannel.py
@@ -52,8 +52,12 @@ class PlayerChannel(Channel):
         self.name = data['name']
         self._server.Send_turnOrder()
 
-    ### Player Game Actions ###
+    def Network_ready(self, data):
+        """Player changed their ready state"""
+        self.ready = data['ready']
+        self._server.checkReady()
 
+    ### Player Game Actions ###
     def Network_discard(self, data):
         card_list = [Card.deserialize(c) for c in data["cards"]]
         self._server.discardCards(card_list)


### PR DESCRIPTION
Added consensus logic to start a new round when everyone was ready. Used this for the first round to remove the server side start. Removed the turn order broadcasts and send a full public info instead so you can see turn order transition in the UI. Adjusted how score broadcast and score sending works so you can review a round and you don't get spammed with scores (which are still in the commandline).

Did introduce new edge case - if a player disconnects during the scoring process you won't get a score broadcast. I could put the scores on the server so they can be semi recovered, but you can manually calculate them if you really care and player disconnection is already a bug.