### PR TITLE
Disconnect bug

### DIFF
--- a/source/server/GameServer.py
+++ b/source/server/GameServer.py
@@ -31,12 +31,11 @@ class GameServer(Server, ServerState):
 
     def disconnect(self, channel):
         """Called by a channel when it disconnects"""
-        player_index = self.players.index(channel)
+        if channel not in self.players:
+            #Disconnecting a channel that never fully joined the game, do nothing
+            return
+        #For players who did join the game need to handle removing them safely
         self.delPlayer(channel)
-        if self.turn_index == player_index and self.in_round:
-            #It was disconnected players turn, need to send newTurn to the next player, accounting for adjusted list
-            self.turn_index = self.turn_index % len(self.players) 
-            self.players[self.turn_index].Send({"action": "startTurn"})
          
     def checkReady(self):
         """Confirm if all players are ready to move on to next round"""
@@ -63,11 +62,22 @@ class GameServer(Server, ServerState):
         self.nextTurn()
 
     def delPlayer(self, player):
-        """Remove a player from the turn order"""
+        """Safely remove a player from the turn order
+        
+        Checks for game over if no more players and quits server
+        Moves turn forward if it was deleted players turn
+        """
+        player_index = self.players.index(player)
         self.players.remove(player)
         self.Send_publicInfo();
+        #Check for no more players
         if len(self.players) == 0:
             self.game_over = True
+        #Check if it was deleted players turn and if so, make sure next player can start
+        if self.turn_index == player_index and self.in_round:
+            self.turn_index = self.turn_index % len(self.players) 
+            self.players[self.turn_index].Send({"action": "startTurn"})
+
 
     def nextTurn(self):
         """Advance to the next trun"""

--- a/source/server/GameServer.py
+++ b/source/server/GameServer.py
@@ -73,6 +73,7 @@ class GameServer(Server, ServerState):
         #Check for no more players
         if len(self.players) == 0:
             self.game_over = True
+            return
         #Check if it was deleted players turn and if so, make sure next player can start
         if self.turn_index == player_index and self.in_round:
             self.turn_index = self.turn_index % len(self.players) 

--- a/source/server/PlayerChannel.py
+++ b/source/server/PlayerChannel.py
@@ -16,7 +16,6 @@ class PlayerChannel(Channel):
         self.ready = False #for consensus transitions
         Channel.__init__(self, *args, **kwargs)
 
-
     def scoreForRound(self, round):
         """Handles getting score for round so we don't error if this player hasn't reported yet"""
         try:


### PR DESCRIPTION
Fixes issues with disconnect for issue #97 

Specifically this fixes 2 problems. One was that we got an npe on disconnecting the last player because that was inherently the active player and it tried to calculate next turn despite having already set gameOver. The other was what I believe was crashing the game - when a player was denied a connection due to a game already being started it ran disconnect code and was unable to find that denied channel it was closing in the player list. That crashed everyone out.
When anything, like a web browser or some other utility, pinged the public address of the server for a remote game it was treated like a client, denied connection because there was a game, and then everything crashed.

Was able to reproduce the crash.