### PR TITLE
Add deck to card definition

### DIFF
--- a/source/RunClient.py
+++ b/source/RunClient.py
@@ -6,7 +6,7 @@ from client.Controller import Controller
 from client.CreateDisplay import CreateDisplay
 from client.HandView import HandView
 from client.TableView import TableView
-# imports below make it added so that can generate executable using pyinstaller.
+# imports below added so that can generate executable using pyinstaller.
 import common.HandAndFoot
 import common.Card
 import client.Button
@@ -35,6 +35,19 @@ def RunClient():
     createDisplay = CreateDisplay(playername)
     handView = HandView(gameControl, createDisplay.display)
     tableView = TableView(createDisplay.display)
+    while(len(tableView.player_names) < 1) or (tableView.player_names.count('guest') > 0 ):
+        note = "waiting for updated list of player names"
+        createDisplay.refresh()
+        handView.nextEvent()
+        connection.Pump()
+        gameControl.Pump()
+        tableView.Pump()
+        handView.update()
+        tableView.playerByPlayer()
+        note = "updating list of player names"
+        createDisplay.render(note)
+        sleep(0.001)
+    gameControl.checkNames(tableView.player_names)
     while True:
         createDisplay.refresh()
         handView.nextEvent()

--- a/source/client/Button.py
+++ b/source/client/Button.py
@@ -2,7 +2,7 @@ import pygame
 import client.UIConstants as UIC
 
 
-class Button():
+class Button:
     """This class draws an rectangle with internal text that can trigger actions
     when clicked on.
 
@@ -20,7 +20,7 @@ class Button():
         self.outline_color = UIC.no_outline_color
 
     def draw(self, win, outline=UIC.no_outline_color):
-        #Call this method to draw the button on the screen
+        # Call this method to draw the button on the screen
         if not outline == UIC.no_outline_color:
             pygame.draw.rect(win, outline,
                              (self.x-UIC.outline_width,
@@ -28,18 +28,17 @@ class Button():
                               self.width+2*UIC.outline_width,
                               self.height+2*UIC.outline_width),
                              0)
-        pygame.draw.rect(win, self.color, (self.x,self.y,self.width,self.height),0)
+        pygame.draw.rect(win, self.color, (self.x, self.y, self.width, self.height), 0)
 
         if self.text != '':
             font = UIC.Big_Text
-            text = font.render(self.text, 1, (0,0,0))
+            text = font.render(self.text, 1, (0, 0, 0))
             win.blit(text, (self.x + (self.width/2 - text.get_width()/2),
                             self.y + (self.height/2 - text.get_height()/2)))
 
     def isOver(self, pos):
-        #pos is the mouse position or a tuple of (x,y) coordinates
-        if pos[0] > self.x and pos[0] < self.x + self.width:
-            if pos[1] > self.y and pos[1] < self.y + self.height:
+        # pos is the mouse position or a tuple of (x,y) coordinates
+        if pos[0] > self.x and pos[0] < (self.x + self.width):
+            if pos[1] > self.y and pos[1] < (self.y + self.height):
                 return True
-
         return False

--- a/source/client/ClientState.py
+++ b/source/client/ClientState.py
@@ -1,7 +1,8 @@
 import importlib
 from common.Card import Card
 
-class ClientState():
+
+class ClientState:
     """ This class store client state for access by different listeners
 
     It tracks things like 'interactivity', a player's hand, discard state, etc.
@@ -10,7 +11,7 @@ class ClientState():
 
     def __init__(self, ruleset = None):
         """Initialize a state tracker for a given client"""
-        if ruleset != None:
+        if ruleset is not None:
             rule_module = "common." + ruleset
         else:
             #This is the unit test case - we may want to put a dummy ruleset in
@@ -18,11 +19,11 @@ class ClientState():
             rule_module = "common.HandAndFoot"
 
         self.rules = importlib.import_module(rule_module)
-        #Turn phase handled by controller
-        self.turn_phase = 'inactive' #hard coded start phase as 'not my turn'
-        self.round = -1 #Start with the 'no current round value
+        # Turn phase handled by controller
+        self.turn_phase = 'inactive'  # hard coded start phase as 'not my turn'
+        self.round = -1  # Start with the 'no current round value'
         self.name = "guest"
-        self.reset() #Start with state cleared for a fresh round
+        self.reset()  # Start with state cleared for a fresh round
 
     def dealtHands(self, hands):
         """Store the extra hands dealt to player for use after first hand is cleared"""
@@ -67,7 +68,7 @@ class ClientState():
 
     def playCards(self, prepared_cards):
         """Move cards from hand to visible"""
-        #First check that all the cards are in your hand
+        # First check that all the cards are in your hand
         tempHand = [x for x in self.hand_cards]
         try:
             for card_group in prepared_cards.values():
@@ -97,7 +98,7 @@ class ClientState():
         """Discard cards from hand"""
         if len(card_list) != self.rules.Discard_Size:
             raise Exception("Wrong discard size. Must discard {0} cards".format(self.rules.Discard_Size))
-        #check that all the cards are in your hand
+        # check that all the cards are in your hand
         tempHand = [x for x in self.hand_cards]
         try:
             for card in card_list:

--- a/source/client/Controller.py
+++ b/source/client/Controller.py
@@ -1,8 +1,9 @@
+import random                  # will be used to assign unique names
 from common.Card import Card
-
 from PodSixNet.Connection import connection, ConnectionListener
 
 Turn_Phases = ['inactive', 'draw', 'forcedAction', 'play']
+forbidden_names = ['guest']
 
 class Controller(ConnectionListener):
     """ This client connects to a GameServer which will host a cardgame
@@ -22,9 +23,33 @@ class Controller(ConnectionListener):
     ### Player Actions ###
     def setName(self):
         """Set up a display name and send it to the server"""
-        displayName = input("Select a display name: ")
-        self._state.name = displayName
-        connection.Send({"action": "displayName", "name": displayName})
+
+        # to prevent duplicate names, displayname = 'guest' is forbidden.
+        # May as well allow other names to be forbidden, too (for fun :) )
+        # if name is in list of forbidden names, then changeName is called.
+        displayName = input("Enter a display name: ")
+        if displayName in forbidden_names:
+            print("Sorry, but that name is forbidden.")
+            changeName()
+        else:
+            self._state.name = displayName
+            connection.Send({"action": "displayName", "name": displayName})
+
+    def checkNames(self, player_names):
+        # Check that no names are duplicated.
+        if player_names.count(self._state.name) > 1 :
+            print(self._state.name + ' is already taken.')
+            self.changeName()
+
+    def changeName(self):
+        # Check that no names are duplicated.
+        name2 = "Bob" + str(random.randint(101, 999))
+        print(self._state.name + ' you shall be named: ' + name2)
+        # it is possible (though unlikely) that two players might still end up with the
+        # same name due to timing, (or 1/898 chance that the same Bob name is chosen)
+        # but we do not deal with these corner cases.
+        self._state.name = name2
+        connection.Send({"action": "displayName", "name": name2})
 
     def setReady(self, readyState):
         """Update the player's ready state with the server"""
@@ -199,6 +224,10 @@ class Controller(ConnectionListener):
         status_info = self._state.getHandStatus()
         connection.Send({"action": "publicInfo", "visible_cards":serialized_cards, "hand_status":status_info})
 
+    def lateJoinScores(self, score):
+        """ When a player joins late the early rounds need to be assigned a score.  This does it. """
+        connection.Send({"action": "reportScore", "score": score})
+
     #######################################
     ### Network event/message callbacks ###
     #######################################
@@ -263,7 +292,6 @@ class Controller(ConnectionListener):
         score = self._state.scoreRound()
         connection.Send({"action": "reportScore", "score": score})
         self.setReady(False)
-
 
     def Network_clearReady(self, data):
         self.setReady(False)

--- a/source/client/HandAndFootButtons.py
+++ b/source/client/HandAndFootButtons.py
@@ -20,11 +20,13 @@ This file is Hand and Foot specific because different games may need additional 
 def CreateButtons(hand_view):
     """This creates the buttons used for HandAndFoot. """
     hand_view.draw_pile = ClickImg(UIC.Back_Img, 10, 25, UIC.Back_Img.get_width(), UIC.Back_Img.get_height(), 0)
-    hand_view.ready_yes_btn = Btn.Button(UIC.White, (UIC.Disp_Width - 150), (UIC.Disp_Height - 70), 125, 25, text='Ready:YES')
+    hand_view.ready_yes_btn = \
+        Btn.Button(UIC.White, (UIC.Disp_Width - 150), (UIC.Disp_Height - 70), 125, 25, text='Ready:YES')
     hand_view.ready_color_idx = 2  # color of outline will be: UIC.outline_colors(ready_color_idx)
-    hand_view.ready_no_btn = Btn.Button(UIC.White, (UIC.Disp_Width - 150), (UIC.Disp_Height - 30), 125, 25, text='Ready:NO')
+    hand_view.ready_no_btn = \
+        Btn.Button(UIC.White, (UIC.Disp_Width - 150), (UIC.Disp_Height - 30), 125, 25, text='Ready:NO')
     hand_view.not_ready_color_idx = 6  # color of outline will be: UIC.outline_colors(ready_color_idx)
-    hand_view.round_indicator_xy = ((UIC.Disp_Width - 50), (UIC.Disp_Height - 30))
+    hand_view.round_indicator_xy = ((UIC.Disp_Width - 100), (UIC.Disp_Height - 20))
     hand_view.sort_status_btn = Btn.Button(UIC.White, 900, 25, 225, 25, text='sort by status')
     hand_view.sort_btn = Btn.Button(UIC.White, 900, 75, 225, 25, text='sort by number')
     hand_view.prepare_card_btn = Btn.Button(UIC.White, 400, 15, 345, 25, text='Selected cards -> prepared cards')
@@ -36,6 +38,7 @@ def CreateButtons(hand_view):
     hand_view.pickup_pile_sz = 0
     hand_view.pickup_pile_outline = UIC.outline_colors[0]
     return
+
 
 def ButtonDisplay(hand_view):
     """ This updates draw pile and action buttons. It is called in HandView.update each render cycle. """
@@ -59,7 +62,7 @@ def ButtonDisplay(hand_view):
         hand_view.ready_yes_btn.draw(hand_view.display, hand_view.ready_yes_btn.outline_color)
         hand_view.ready_no_btn.draw(hand_view.display, hand_view.ready_no_btn.outline_color)
     else:
-        hand_view.labelMedium(str(Meld_Threshold[hand_view.round_index]),
+        hand_view.labelMedium(str(Meld_Threshold[hand_view.round_index]) + "points to meld",
                               hand_view.round_indicator_xy[0], hand_view.round_indicator_xy[1])
     hand_view.sort_status_btn.draw(hand_view.display, hand_view.sort_status_btn.outline_color)
     hand_view.sort_btn.draw(hand_view.display, hand_view.sort_btn.outline_color)
@@ -128,8 +131,8 @@ def ClickedButton(hand_view, pos):
         hand_view.not_ready_color_idx = 8  # color of outline will be: UIC.outline_colors(not_ready_color_idx)
     elif hand_view.controller._state.round == -1 and hand_view.ready_no_btn.isOver(pos):
         hand_view.controller.setReady(False)
-        # comment out next line and the line about 5 lines above this where hand_view.last_round_hand is defined
-        # if you don't want last round's hand to reappear.
+        # if you don't want last round's hand to reappear, then
+        # comment out line about 7 lines above this where hand_view.last_round_hand is defined
         hand_view.hand_info = hand_view.last_round_hand
         hand_view.ready_color_idx = 2  # color of outline will be: UIC.outline_colors(ready_color_idx)
         hand_view.not_ready_color_idx = 6  # color of outline will be: UIC.outline_colors(not_ready_color_idx)

--- a/source/client/HandAndFootButtons.py
+++ b/source/client/HandAndFootButtons.py
@@ -62,7 +62,7 @@ def ButtonDisplay(hand_view):
         hand_view.ready_yes_btn.draw(hand_view.display, hand_view.ready_yes_btn.outline_color)
         hand_view.ready_no_btn.draw(hand_view.display, hand_view.ready_no_btn.outline_color)
     else:
-        hand_view.labelMedium(str(Meld_Threshold[hand_view.round_index]) + "points to meld",
+        hand_view.labelMedium(str(Meld_Threshold[hand_view.controller._state.round]) + "points to meld",
                               hand_view.round_indicator_xy[0], hand_view.round_indicator_xy[1])
     hand_view.sort_status_btn.draw(hand_view.display, hand_view.sort_status_btn.outline_color)
     hand_view.sort_btn.draw(hand_view.display, hand_view.sort_btn.outline_color)

--- a/source/client/HandAndFootButtons.py
+++ b/source/client/HandAndFootButtons.py
@@ -1,14 +1,15 @@
 import pygame
 import client.Button as Btn
 from client.ClickableImage import ClickableImage as ClickImg
+from common.HandAndFoot import Meld_Threshold
 import client.HandManagement as HandManagement
 import client.UIConstants as UIC
 from client.UICardWrapper import UICardWrapper
 
 """This file contains methods used in displaying the buttons that enable the user to take actions
 
-If a button is clicked then generally two actions take place -- one action initiates communication with the server 
-and the second updates the display to reflect the action taken.  
+If a button is clicked, then typically 1 or 2 methods are called. The first initiates communication with the server, 
+and when necessary a 2nd updates the display to reflect the action taken.  
 Discards are confirmed within the GUI, and that code is currently split between this file and HandView.
 
 This file is Hand and Foot specific because different games may need additional buttons, and may need them arranged
@@ -23,6 +24,7 @@ def CreateButtons(hand_view):
     hand_view.ready_color_idx = 2  # color of outline will be: UIC.outline_colors(ready_color_idx)
     hand_view.ready_no_btn = Btn.Button(UIC.White, (UIC.Disp_Width - 150), (UIC.Disp_Height - 30), 125, 25, text='Ready:NO')
     hand_view.not_ready_color_idx = 6  # color of outline will be: UIC.outline_colors(ready_color_idx)
+    hand_view.round_indicator_xy = ((UIC.Disp_Width - 50), (UIC.Disp_Height - 30))
     hand_view.sort_status_btn = Btn.Button(UIC.White, 900, 25, 225, 25, text='sort by status')
     hand_view.sort_btn = Btn.Button(UIC.White, 900, 75, 225, 25, text='sort by number')
     hand_view.prepare_card_btn = Btn.Button(UIC.White, 400, 15, 345, 25, text='Selected cards -> prepared cards')
@@ -56,6 +58,9 @@ def ButtonDisplay(hand_view):
     if hand_view.controller._state.round == -1:
         hand_view.ready_yes_btn.draw(hand_view.display, hand_view.ready_yes_btn.outline_color)
         hand_view.ready_no_btn.draw(hand_view.display, hand_view.ready_no_btn.outline_color)
+    else:
+        hand_view.labelMedium(str(Meld_Threshold[hand_view.round_index]),
+                              hand_view.round_indicator_xy[0], hand_view.round_indicator_xy[1])
     hand_view.sort_status_btn.draw(hand_view.display, hand_view.sort_status_btn.outline_color)
     hand_view.sort_btn.draw(hand_view.display, hand_view.sort_btn.outline_color)
     hand_view.prepare_card_btn.draw(hand_view.display, hand_view.prepare_card_btn.outline_color)
@@ -71,7 +76,6 @@ def ClickedButton(hand_view, pos):
     if hand_view.pickup_pile_sz > 0:
         if hand_view.pickup_pile.isOver(pos):
             hand_view.controller.pickUpPile()
-            HandManagement.PreparedCardsPlayed(hand_view)
     if hand_view.draw_pile.isOver(pos):
         hand_view.controller.draw()
     elif hand_view.sort_btn.isOver(pos):
@@ -107,7 +111,6 @@ def ClickedButton(hand_view, pos):
         # take care of assigning values and marking wilds as prepared.
     elif hand_view.play_prepared_cards_btn.isOver(pos):
         hand_view.controller.play()
-        HandManagement.PreparedCardsPlayed(hand_view)
     elif hand_view.clear_prepared_cards_btn.isOver(pos):
         hand_view.controller.clearPreparedCards()
         hand_view.hand_info = HandManagement.ClearPreparedCardsInHandView(hand_view.hand_info)
@@ -125,7 +128,7 @@ def ClickedButton(hand_view, pos):
         hand_view.not_ready_color_idx = 8  # color of outline will be: UIC.outline_colors(not_ready_color_idx)
     elif hand_view.controller._state.round == -1 and hand_view.ready_no_btn.isOver(pos):
         hand_view.controller.setReady(False)
-        # comment out next line and the line above where hand_view.last_round_hand is defined
+        # comment out next line and the line about 5 lines above this where hand_view.last_round_hand is defined
         # if you don't want last round's hand to reappear.
         hand_view.hand_info = hand_view.last_round_hand
         hand_view.ready_color_idx = 2  # color of outline will be: UIC.outline_colors(ready_color_idx)

--- a/source/client/HandManagement.py
+++ b/source/client/HandManagement.py
@@ -17,27 +17,20 @@ def WrapHand(hand_view, updated_hand, wrapped_hand):
     Variables from hand_view used: hand_view.hand_scaling (scaling and spacing of cards)
     """
     card_xy = (10, UIC.Table_Hand_Border + 40)
-    old_wrapped_hand = wrapped_hand
-    # ToDo - only need 2 of 3: old_wrapped_hand, wrapped_hand, updated_wrapped_hand -- keep latter.
     updated_wrapped_hand = []
     if not updated_hand == []:
         for card in updated_hand:
             newcard = True
             # Check to see if card already in hand, and if it is change newcard to False.
             # Do this so if card already in hand, then its position and status is preserved.
-            # ToDo: change logic of loops so all new cards are on the far right when you pick up the pile.
-            #  Else new cards will fill in the gaps until you hit max card, and can get some weird behavior.
-            for already_wrapped in old_wrapped_hand:
+            for already_wrapped in wrapped_hand:
                 if newcard and card == already_wrapped.card:
                     newcard = False
                     card_wrapped = already_wrapped
                     # reset card_xy so new cards appear to right of old cards (card_xy[0] is max x-coord of cards).
                     card_xy = (max(card_xy[0], card_wrapped.img_clickable.x), card_xy[1])
-                    old_wrapped_hand.remove(already_wrapped)
-                    # updated_hand.remove(card) # added this line to deck, so could put all new cards to far right
-                    # above line seemed to remove other cards
+                    wrapped_hand.remove(already_wrapped)
             if newcard:
-                # something failed when I tried this: for card in updated_hand:
                 card_xy = (card_xy[0] + hand_view.hand_scaling[1], card_xy[1])
                 card_wrapped = UICardWrapper(card, card_xy, hand_view.hand_scaling[0])
             updated_wrapped_hand.append(card_wrapped)
@@ -45,7 +38,7 @@ def WrapHand(hand_view, updated_hand, wrapped_hand):
         # sort cards by location, so they will display more attractively and so RefreshXY will work properly if called.
         updated_wrapped_hand.sort(key=lambda wc: wc.img_clickable.x)
         # Next section checks all cards will be visible, and if hand too large, then it shrinks cards.
-        # Once length of hand <= original size it rescales cards to original size.
+        # Once length of hand <= size at beginning of game it rescales cards to original size.
         maxX = UIC.Disp_Width - hand_view.hand_scaling[1]
         if card_xy[0] > maxX:
             # RefreshXY will remove any gaps between cards, and if necessary rescale the cards.
@@ -73,8 +66,7 @@ def ClearSelectedCards(wrapped_hand):
 
 
 def RefreshXY(hand_view, original_wrapped_hand, layout_option=1):
-    """After sorting need to refresh XY coords, may also wish to refresh card's xy coordinates when hand large"""
-
+    # After sorting need to refresh XY coords, may also wish to refresh card's xy coordinates when hand large
     maxX = UIC.Disp_Width - hand_view.hand_scaling[1]
     if not layout_option == 1:
         print('the only layout supported now is cards in a line, left to right')
@@ -85,7 +77,7 @@ def RefreshXY(hand_view, original_wrapped_hand, layout_option=1):
         element.img_clickable.y = card_xy[1]
         card_xy = (card_xy[0] + hand_view.hand_scaling[1], card_xy[1])
         refreshed_wrapped_hand.append(element)
-    if (card_xy[0] > maxX):
+    if card_xy[0] > maxX:
         scalingfactor = maxX / card_xy[0]
         hand_view.hand_scaling = (scalingfactor * hand_view.hand_scaling[0], scalingfactor * hand_view.hand_scaling[1])
         rescaled_wrapped_hand = RescaleCards(hand_view, refreshed_wrapped_hand)

--- a/source/client/HandView.py
+++ b/source/client/HandView.py
@@ -37,12 +37,12 @@ class HandView:
         self.num_wilds = 0
         self.wild_cards = []
         self.selected_list = []
-        self.round_index = 0
+        self.next_round = 0
         self.round_advance = False
         self.ready_color_idx = 2
         self.not_ready_color_idx = 6
         # --- Hand And Foot Specific:
-        self.betweenrounds = ['Welcome to a new game.  This is the round of ' + str(Meld_Threshold[0]) + '.',
+        self.betweenrounds = ['Welcome to a new game.  This is the round of ' + str(Meld_Threshold[self.next_round]) + '.',
                               'To draw click on the deck of cards (upper left).',
                               'To discard select ONE card & double click on discard button. ',
                               'To pick up pile PREPARE necessary cards & then click on discard pile. ',
@@ -56,13 +56,20 @@ class HandView:
         if self.controller._state.round == -1:
             self.mesgBetweenRounds(self.betweenrounds)
             if self.round_advance:
-                self.round_index = self.round_index + 1
-                if self.round_index < len(Meld_Threshold):
-                    self.betweenrounds[0] = 'This is the round of ' + str(Meld_Threshold[self.round_index]) + ' ! '
+                self.next_round = self.next_round + 1
+                if self.next_round < len(Meld_Threshold):
+                    self.betweenrounds[0] = 'This is the round of ' + str(Meld_Threshold[self.next_round]) + ' ! '
                 else:
                     self.betweenrounds = ['Game has concluded. Scores for each round can be found in command window.']
                 self.round_advance = False
         else:
+            if not self.next_round == self.controller._state.round:
+                # Need this to true up next_round if a player joins mid-game.
+                skipped_rounds =  self.controller._state.round - self.next_round
+                for idx in range(skipped_rounds):
+                    score = 0
+                    self.controller.lateJoinScores(score)
+                self.next_round = self.controller._state.round
             self.round_advance = True
             # reset outline colors on ready buttons to what they need to be at the start of the "between rounds" state.
             self.ready_color_idx = 2

--- a/source/client/HandView.py
+++ b/source/client/HandView.py
@@ -74,10 +74,6 @@ class HandView:
         elif not self.last_hand == self.current_hand:
             self.hand_info = HandManagement.WrapHand(self, self.current_hand, self.hand_info)
         HandManagement.ShowHolding(self, self.hand_info)  # displays hand
-        ''' if self.refresh_flag:  # if needed to rescale card size, then refreshXY again.
-            # Todo: Do we need refresh_flag at all??
-            self.hand_info = HandManagement.RefreshXY(self, self.hand_info)
-        '''
         HandAndFootButtons.ButtonDisplay(self)
 
     def nextEvent(self):

--- a/source/client/HandView.py
+++ b/source/client/HandView.py
@@ -74,9 +74,10 @@ class HandView:
         elif not self.last_hand == self.current_hand:
             self.hand_info = HandManagement.WrapHand(self, self.current_hand, self.hand_info)
         HandManagement.ShowHolding(self, self.hand_info)  # displays hand
-        if self.refresh_flag:  # if needed to rescale card size, then refreshXY again.
+        ''' if self.refresh_flag:  # if needed to rescale card size, then refreshXY again.
             # Todo: Do we need refresh_flag at all??
             self.hand_info = HandManagement.RefreshXY(self, self.hand_info)
+        '''
         HandAndFootButtons.ButtonDisplay(self)
 
     def nextEvent(self):

--- a/source/client/TableView.py
+++ b/source/client/TableView.py
@@ -20,7 +20,6 @@ class TableView(ConnectionListener):
         self.playerByPlayer()
         self.results = {}
 
-
     def playerByPlayer(self):
         self.compressSets(self.visible_cards)
         num_players = len(self.player_names)
@@ -43,7 +42,7 @@ class TableView(ConnectionListener):
                 foot = self.hand_status[idx][2]
                 player_text1 = player_name
                 player_text2 = str(numcards)
-                if (foot > 0):
+                if foot > 0:
                     player_text2 = player_text2 + ' cards (in hand)'
                 else:
                     player_text2 = player_text2 + ' cards (in foot)'
@@ -58,20 +57,19 @@ class TableView(ConnectionListener):
                 player_text2 = ' (should be joining soon)'
                 text_surface1, text_rect1 = self.textObjects(player_text1, UIC.Medium_Text, UIC.Black)
                 text_surface2, text_rect2 = self.textObjects(player_text2, UIC.Small_Text, UIC.Black)
-            y_coord =  0.05 * UIC.Disp_Height
+            y_coord = 0.05 * UIC.Disp_Height
             text_rect1.center = ((bk_grd_rect[0] + 0.5 * players_sp_w), (bk_grd_rect[1] + y_coord))
             self.display.blit(text_surface1, text_rect1)
             y_coord = y_coord + UIC.Medium_Text_Feed
             text_rect2.center = ((bk_grd_rect[0] + 0.5 * players_sp_w), (bk_grd_rect[1] + y_coord))
             self.display.blit(text_surface2, text_rect2)
-            # y_coord = y_coord + UIC.Medium_Text_Feed
             for key in melded_summary:
-                if (melded_summary[key][0] > 0):
+                if melded_summary[key][0] > 0:
                     detail_str = str(melded_summary[key][0])
-                    detail_str = detail_str + ': (' + str(melded_summary[key][1]) + ', ' + str(melded_summary[key][2]) +')'
-                    if (melded_summary[key][0] > 6):
+                    detail_str = detail_str + ': (' + str(melded_summary[key][1]) + ', ' + str(melded_summary[key][2]) + ')'
+                    if melded_summary[key][0] > 6:
                         detail_str = detail_str + '<<<'
-                    if (melded_summary[key][2] == 0):
+                    if melded_summary[key][2] == 0:
                         text_color = UIC.Red
                     else:
                         text_color = UIC.Black
@@ -86,7 +84,7 @@ class TableView(ConnectionListener):
                     elif key == 13:
                         player_text = 'Kings ' + detail_str
                     else:
-                        player_text =  str(key) + "'s  " + detail_str
+                        player_text = str(key) + "'s  " + detail_str
                     text_surface, text_rect = self.textObjects(player_text, UIC.Small_Text, text_color)
                     text_rect.center = ((bk_grd_rect[0] + 0.5 * players_sp_w), (bk_grd_rect[1] + ykey))
                     self.display.blit(text_surface, text_rect)
@@ -94,13 +92,12 @@ class TableView(ConnectionListener):
             if len(self.results) > 0:
                 player_total_points = str(self.results[player_name])
                 text_surface, text_rect = self.textObjects(player_total_points, UIC.Small_Text, UIC.Blue)
-                text_rect.center = (bk_grd_rect[0] + 0.5 * players_sp_w,\
+                text_rect.center = (bk_grd_rect[0] + 0.5 * players_sp_w,
                                     bk_grd_rect[1] + y_coord + (UIC.Small_Text_Feed * 13))
                 self.display.blit(text_surface, text_rect)
             # Move to next players rectangle and color:
             bk_grd_rect = (bk_grd_rect[0] + players_sp_w, bk_grd_rect[1], bk_grd_rect[2], bk_grd_rect[3])
             color_index = (color_index + 1) % len(UIC.table_grid_colors)
-
 
     def compressSets(self, v_cards):
         """ Don't have space to display every card. Summarize sets of cards here. """
@@ -154,6 +151,6 @@ class TableView(ConnectionListener):
             self.results_cmdscreen= self.results_cmdscreen + "  [" + \
                                     self.player_names[idx] + ": " + str(round_scores[idx]) + " " + \
                                     str(total_scores[idx]) +  "] \r \n "
-            print("{0} scored {1} this round, and  has {2} total".format(self.player_names[idx], round_scores[idx], total_scores[idx]))
+            print("{0} scored {1} this round, and  has {2} total".format(
+                self.player_names[idx], round_scores[idx], total_scores[idx]))
         print(self.results_cmdscreen)
-

--- a/source/client/TableView.py
+++ b/source/client/TableView.py
@@ -89,8 +89,12 @@ class TableView(ConnectionListener):
                     text_rect.center = ((bk_grd_rect[0] + 0.5 * players_sp_w), (bk_grd_rect[1] + ykey))
                     self.display.blit(text_surface, text_rect)
                 # Print cumulative score for this player.
+                # If player just joined game then self.results[player_name] is null.  Need to catch that.
             if len(self.results) > 0:
-                player_total_points = str(self.results[player_name])
+                if self.results.get(player_name) is not None:
+                    player_total_points = str(self.results[player_name])
+                else:
+                    player_total_points = '---'
                 text_surface, text_rect = self.textObjects(player_total_points, UIC.Small_Text, UIC.Blue)
                 text_rect.center = (bk_grd_rect[0] + 0.5 * players_sp_w,
                                     bk_grd_rect[1] + y_coord + (UIC.Small_Text_Feed * 13))

--- a/source/client/UIConstants.py
+++ b/source/client/UIConstants.py
@@ -63,7 +63,7 @@ Back_Img = pygame.transform.rotozoom(Back_Img, 0, scale)
 
 # Load images for full deck of cards:
 suit_letter = 'N'  # this doesn't distinguish between red & black Jokers
-temp_deck = Card.getStandardDeck()
+temp_deck = Card.getStandardDeck(int(0))
 card_images = {}
 card_images['0N'] = pygame.image.load(os.path.join('bundle_data', 'cardimages', 'card0N.png'))
 for card in temp_deck:

--- a/source/common/Card.py
+++ b/source/common/Card.py
@@ -1,4 +1,4 @@
-class Card():
+class Card:
     """ This defines a playing card for use in the game
 
     Every card is an integer number and a suit (jokers have suit None and number 0)
@@ -10,8 +10,8 @@ class Card():
         self.suit = suit
 
         if suit is None:
-            self.number = 0 #Jokers are always 0
-        elif number not in range(1,14): #range includes start but not stop number
+            self.number = 0  # Jokers are always 0
+        elif number not in range(1, 14):  # range includes start but not stop number
             raise ValueError("Invalid card number")
         else:
             self.number = number
@@ -23,7 +23,7 @@ class Card():
             return 'Black'
         if self.suit in ['Hearts', 'Diamonds']:
             return 'Red'
-        return None #For jokers
+        return None  # For jokers
 
     def serialize(self):
         """translate into a format podsixnet can translate"""

--- a/source/common/Card.py
+++ b/source/common/Card.py
@@ -4,7 +4,7 @@ class Card():
     Every card is an integer number and a suit (jokers have suit None and number 0)
     A card can tell you its color for rule checking
     """
-    def __init__(self, number, suit):
+    def __init__(self, number, suit, deck):
         if suit not in [None, 'Spades', 'Hearts', 'Diamonds', 'Clubs']:
             raise ValueError("Invalid Suit")
         self.suit = suit
@@ -16,6 +16,8 @@ class Card():
         else:
             self.number = number
 
+        self.deck = int(deck)
+
     def getColor(self):
         if self.suit in ['Spades', 'Clubs']:
             return 'Black'
@@ -25,12 +27,12 @@ class Card():
 
     def serialize(self):
         """translate into a format podsixnet can translate"""
-        return (self.number, self.suit)
+        return (self.number, self.suit, self.deck)
 
     @staticmethod
     def deserialize(representation):
         """create a card object from the podsixnet transportable serialization"""
-        return Card(representation[0], representation[1])
+        return Card(representation[0], representation[1], representation[2])
 
     def __str__(self):
         if self.suit is None:
@@ -50,68 +52,68 @@ class Card():
         return "({0}, {1})".format(self.number, self.suit)
 
     def __eq__(self, other):
-        return (self.number == other.number) and (self.suit == other.suit)
+        return (self.number == other.number) and (self.suit == other.suit) and (self.deck == other.deck)
 
     def __ne__(self, other):
         return not self.__eq__(other)
 
     @staticmethod
-    def getStandardDeck():
+    def getStandardDeck(num):
         """Provides a standard 52 card deck"""
-        return [Card(1, 'Spades'),
-                Card(2, 'Spades'),
-                Card(3, 'Spades'),
-                Card(4, 'Spades'),
-                Card(5, 'Spades'),
-                Card(6, 'Spades'),
-                Card(7, 'Spades'),
-                Card(8, 'Spades'),
-                Card(9, 'Spades'),
-                Card(10, 'Spades'),
-                Card(11, 'Spades'),
-                Card(12, 'Spades'),
-                Card(13, 'Spades'),
-                Card(1, 'Hearts'),
-                Card(2, 'Hearts'),
-                Card(3, 'Hearts'),
-                Card(4, 'Hearts'),
-                Card(5, 'Hearts'),
-                Card(6, 'Hearts'),
-                Card(7, 'Hearts'),
-                Card(8, 'Hearts'),
-                Card(9, 'Hearts'),
-                Card(10, 'Hearts'),
-                Card(11, 'Hearts'),
-                Card(12, 'Hearts'),
-                Card(13, 'Hearts'),
-                Card(1, 'Diamonds'),
-                Card(2, 'Diamonds'),
-                Card(3, 'Diamonds'),
-                Card(4, 'Diamonds'),
-                Card(5, 'Diamonds'),
-                Card(6, 'Diamonds'),
-                Card(7, 'Diamonds'),
-                Card(8, 'Diamonds'),
-                Card(9, 'Diamonds'),
-                Card(10, 'Diamonds'),
-                Card(11, 'Diamonds'),
-                Card(12, 'Diamonds'),
-                Card(13, 'Diamonds'),
-                Card(1, 'Clubs'),
-                Card(2, 'Clubs'),
-                Card(3, 'Clubs'),
-                Card(4, 'Clubs'),
-                Card(5, 'Clubs'),
-                Card(6, 'Clubs'),
-                Card(7, 'Clubs'),
-                Card(8, 'Clubs'),
-                Card(9, 'Clubs'),
-                Card(10, 'Clubs'),
-                Card(11, 'Clubs'),
-                Card(12, 'Clubs'),
-                Card(13, 'Clubs')]
+        return [Card(1, 'Spades', num),
+                Card(2, 'Spades', num),
+                Card(3, 'Spades', num),
+                Card(4, 'Spades', num),
+                Card(5, 'Spades', num),
+                Card(6, 'Spades', num),
+                Card(7, 'Spades', num),
+                Card(8, 'Spades', num),
+                Card(9, 'Spades', num),
+                Card(10, 'Spades', num),
+                Card(11, 'Spades', num),
+                Card(12, 'Spades', num),
+                Card(13, 'Spades', num),
+                Card(1, 'Hearts', num),
+                Card(2, 'Hearts', num),
+                Card(3, 'Hearts', num),
+                Card(4, 'Hearts', num),
+                Card(5, 'Hearts', num),
+                Card(6, 'Hearts', num),
+                Card(7, 'Hearts', num),
+                Card(8, 'Hearts', num),
+                Card(9, 'Hearts', num),
+                Card(10, 'Hearts', num),
+                Card(11, 'Hearts', num),
+                Card(12, 'Hearts', num),
+                Card(13, 'Hearts', num),
+                Card(1, 'Diamonds', num),
+                Card(2, 'Diamonds', num),
+                Card(3, 'Diamonds', num),
+                Card(4, 'Diamonds', num),
+                Card(5, 'Diamonds', num),
+                Card(6, 'Diamonds', num),
+                Card(7, 'Diamonds', num),
+                Card(8, 'Diamonds', num),
+                Card(9, 'Diamonds', num),
+                Card(10, 'Diamonds', num),
+                Card(11, 'Diamonds', num),
+                Card(12, 'Diamonds', num),
+                Card(13, 'Diamonds', num),
+                Card(1, 'Clubs', num),
+                Card(2, 'Clubs', num),
+                Card(3, 'Clubs', num),
+                Card(4, 'Clubs', num),
+                Card(5, 'Clubs', num),
+                Card(6, 'Clubs', num),
+                Card(7, 'Clubs', num),
+                Card(8, 'Clubs', num),
+                Card(9, 'Clubs', num),
+                Card(10, 'Clubs', num),
+                Card(11, 'Clubs', num),
+                Card(12, 'Clubs', num),
+                Card(13, 'Clubs', num)]
 
     @staticmethod
-    def getJokerDeck():
+    def getJokerDeck(num):
         """Provides a deck with jokers based on the standard deck"""
-        return Card.getStandardDeck() + [Card(0, None), Card(0, None)]
+        return Card.getStandardDeck(num) + [Card(0, None, num), Card(0, None, num)]

--- a/source/common/HandAndFoot.py
+++ b/source/common/HandAndFoot.py
@@ -24,9 +24,9 @@ def numDecks(numPlayers):
     """Specify how many decks of cards to put in the draw pile"""
     return math.ceil(numPlayers*1.5)
 
-def singleDeck():
-    """return a single deck of the correct type"""
-    return Card.getJokerDeck()
+def singleDeck(n):
+    """return a single deck of the correct type, n designates which deck of the numDecks to be used"""
+    return Card.getJokerDeck(n)
 
 def isWild(card):
     """returns true if a card is a wild"""

--- a/source/common/HandAndFoot.py
+++ b/source/common/HandAndFoot.py
@@ -15,25 +15,29 @@ Pickup_Size = 8
 Discard_Size = 1
 
 Meld_Threshold = [50, 90, 120, 150]
-Number_Rounds = len(Meld_Threshold) #For convenience
+Number_Rounds = len(Meld_Threshold)  # For convenience
 
 Deal_Size = 11
 Hands_Per_Player = 2
+
 
 def numDecks(numPlayers):
     """Specify how many decks of cards to put in the draw pile"""
     return math.ceil(numPlayers*1.5)
 
+
 def singleDeck(n):
     """return a single deck of the correct type, n designates which deck of the numDecks to be used"""
     return Card.getJokerDeck(n)
 
+
 def isWild(card):
     """returns true if a card is a wild"""
-    if card.number in [0,2]:
+    if card.number in [0, 2]:
         return True
     else:
         return False
+
 
 def getKeyOptions(card):
     """returns the possible keys for the groups the card can go in"""
@@ -42,7 +46,8 @@ def getKeyOptions(card):
             raise Exception("Cannot play 3s")
         return [card.number]
     else:
-        return [1,4,5,6,7,8,9,10,11,12,13]
+        return [1, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+
 
 def canPlayGroup(key, card_group):
     """checks if a group can be played
@@ -50,11 +55,11 @@ def canPlayGroup(key, card_group):
     returns True if it can, otherwise raises an exception with an explanation
     """
     if len(card_group) == 0:
-        return True # Need to allow empty groups to be "played" due to some side-effects of how we combined dictionaries
+        return True  # Need to allow empty groups to be "played" due to side-effects of how we combined dictionaries
     if key == 3:
         raise Exception("Illegal key - cannot play 3s")
     if len(card_group) < 3: 
-        raise Exception("Too few cards in group - minimum is 3");
+        raise Exception("Too few cards in group - minimum is 3")
     typeDiff = 0
     for card in card_group:
         if isWild(card):
@@ -66,6 +71,7 @@ def canPlayGroup(key, card_group):
     if typeDiff > 0:
         return True
     raise Exception("Too many wilds in {0} group.".format(key))
+
 
 def canMeld(prepared_cards, round_index):
     """Determines if a set of card groups is a legal meld"""
@@ -90,7 +96,7 @@ def canPickupPile(top_card, prepared_cards, played_cards, round_index):
         if len(key_opts) > 1:
             raise Exception("Cannot pickup the pile on wilds")
         top_key = key_opts[0]
-    #check suggested play contains 2 cards matching the top card
+    # check suggested play contains 2 cards matching the top card
     top_group = prepared_cards.setdefault(top_key, [])
     total = 0
     for card in top_group:
@@ -98,7 +104,7 @@ def canPickupPile(top_card, prepared_cards, played_cards, round_index):
             total += 1
     if total < 2:
         raise Exception("Cannot pickup the pile without 2 prepared cards matching the top card of the discard pile")
-    #check suggested play is legal (using adjusted deep copy of prepared cards)
+    # check suggested play is legal (using adjusted deep copy of prepared cards)
     temp_prepared = {}
     for key, card_group in prepared_cards.items():
         temp_prepared[key] = [x for x in card_group]
@@ -106,16 +112,18 @@ def canPickupPile(top_card, prepared_cards, played_cards, round_index):
             temp_prepared[key].append(top_card)
     return canPlay(temp_prepared, played_cards, round_index)
 
+
 def canPlay(prepared_cards, played_cards, round_index):
     """Confirms if playing the selected cards is legal"""
-    if not played_cards: #empty dicts evaluate to false (as does None)
+    if not played_cards:   # empty dicts evaluate to false (as does None)
         return canMeld(prepared_cards, round_index)
-    #Combine dictionaries to get the final played cards if suggest cards played
+    # Combine dictionaries to get the final played cards if suggest cards played
     combined_cards = combineCardDicts(prepared_cards, played_cards)
-    #Confirm each combined group is playable
+    # Confirm each combined group is playable
     for key, card_group in combined_cards.items():
         canPlayGroup(key, card_group)
     return True
+
 
 def combineCardDicts(dict1, dict2):
     """Combine two dictionaries of cards, such as played and to be played cards"""
@@ -132,9 +140,9 @@ def combineCardDicts(dict1, dict2):
 
 def cardValue(card):
     """Returns the point value for a card"""
-    if card.number in [4,5,6,7,8,9]:
+    if card.number in [4, 5, 6, 7, 8, 9]:
         return 5
-    if card.number in [10,11,12,13]:
+    if card.number in [10, 11, 12, 13]:
         return 10
     if card.number == 1:
         return 15
@@ -148,6 +156,7 @@ def cardValue(card):
         if card.getColor() == 'Red':
             return 500
     raise ValueError("Card submitted is not a legal playing card option")
+
 
 def goneOut(played_cards):
     """Returns true if the played set of cards meets the requirements to go out
@@ -166,6 +175,7 @@ def goneOut(played_cards):
     if clean and dirty:
         return True
     return False
+
 
 def caniestaHelper(card_group):
     """Returns a constant indicating canista status for the set
@@ -186,6 +196,7 @@ def caniestaHelper(card_group):
             return 'Clean'
     return None
 
+
 def calculateBonuses(played_cards, went_out):
     """Scores a card_group, including Caniesta bonuses"""
     bonus = 0
@@ -199,12 +210,14 @@ def calculateBonuses(played_cards, went_out):
             bonus += 300
     return bonus
 
+
 def scoreGroup(card_group):
     """Scores a group of cards for raw value"""
     score = 0
     for card in card_group:
         score += cardValue(card)
     return score
+
 
 def scoreRound(played_cards, unplayed_cards, went_out):
     """Calculates the score for a player for a round"""

--- a/source/server/GameServer.py
+++ b/source/server/GameServer.py
@@ -4,7 +4,6 @@ from server.ServerState import ServerState
 from PodSixNet.Server import Server
 from PodSixNet.Channel import Channel
 
-
 class GameServer(Server, ServerState):
     channelClass = PlayerChannel
 
@@ -21,13 +20,15 @@ class GameServer(Server, ServerState):
 
     def Connected(self, channel, addr):
         """Called by podsixnet when a client connects and establishes a channel"""
-        if self.round >= 0:
-            print(channel, 'Client tried to connect during active game')
+        if self.in_round:
+            print(channel, 'Client tried to connect during active round, try again between rounds')
             channel.Send({"action": "connectionDenied"})
         else:
             self.players.append(channel)
             self.Send_publicInfo()
             print(channel, "Client connected")
+            if self.round >= 0:
+                print(channel, 'a client joined between rounds')
 
     def disconnect(self, channel):
         """Called by a channel when it disconnects"""
@@ -57,7 +58,6 @@ class GameServer(Server, ServerState):
         self.prepareRound(len(self.players))
         for player in self.players:
             player.Send_deal(self.dealHands(), self.round)
-        #set turn index to the dealer then start play
         self.turn_index = self.round
         self.nextTurn()
 
@@ -69,7 +69,7 @@ class GameServer(Server, ServerState):
         """
         player_index = self.players.index(player)
         self.players.remove(player)
-        self.Send_publicInfo();
+        self.Send_publicInfo()
         #Check for no more players
         if len(self.players) == 0:
             self.game_over = True

--- a/source/server/PlayerChannel.py
+++ b/source/server/PlayerChannel.py
@@ -6,7 +6,7 @@ class PlayerChannel(Channel):
 
     def __init__(self, *args, **kwargs):
         """This overrides the lower lvl channel init
-        It's a place to set any client information thats provided from the server
+        It's a place to set any client information that's provided from the server
         """
         self.name = "guest"
         #visible cards and hand status are public info
@@ -17,7 +17,7 @@ class PlayerChannel(Channel):
         Channel.__init__(self, *args, **kwargs)
 
     def scoreForRound(self, round):
-        """Handles getting score for round so we don't error if this player hasn't reported yet"""
+        """ Handles getting score for round so we don't error if this player hasn't reported yet."""
         try:
             return self.scores[round]
         except:

--- a/source/server/ServerState.py
+++ b/source/server/ServerState.py
@@ -33,8 +33,8 @@ class ServerState():
         Clears out the discard pile
         """
         deck = []
-        for _ in range(0, self.rules.numDecks(numPlayers)):
-            for card in self.rules.singleDeck():
+        for deck_number in range(0, self.rules.numDecks(numPlayers)):
+            for card in self.rules.singleDeck(deck_number):
                 deck.append(card)
         random.shuffle(deck)
         self.draw_pile = deck
@@ -61,7 +61,7 @@ class ServerState():
 
     def getDiscardInfo(self):
         """Provides the top card and size of the discard pile as a tuple"""
-        top_card = Card(0, None) #If pile is empty we need a default card since None doesn't serialize
+        top_card = Card(0, None, 0) #If pile is empty we still need a default card since None doesn't serialize
         if len(self.discard_pile) > 0:
             top_card = self.discard_pile[-1]
         return [top_card, len(self.discard_pile)]

--- a/source/server/ServerState.py
+++ b/source/server/ServerState.py
@@ -3,6 +3,7 @@ from common.Card import Card
 import random
 import importlib
 
+
 class ServerState():
     """This tracks the game's shared state on the server.
 
@@ -13,16 +14,16 @@ class ServerState():
     """
 
     def __init__(self, ruleset = None):
-        if ruleset != None:
+        if ruleset is not None:
             rule_module = "common." + ruleset
         else:
-            #This is the unit test case - we may want to put a dummy ruleset in
+            # This is the unit test case - we may want to put a dummy ruleset in
             print("In unittest mode - using HandAndFoot rules")
             rule_module = "common.HandAndFoot"
 
         self.rules = importlib.import_module(rule_module)
         self.draw_pile = []
-        self.round = -1 #Start at negative so first nextRound call increments to 0
+        self.round = -1  # Start at negative so first nextRound call increments to 0
         self.discard_pile = []
         self.turn_index = 0
 
@@ -61,7 +62,7 @@ class ServerState():
 
     def getDiscardInfo(self):
         """Provides the top card and size of the discard pile as a tuple"""
-        top_card = Card(0, None, 0) #If pile is empty we still need a default card since None doesn't serialize
+        top_card = Card(0, None, 0)  # If pile is empty we still need a default card since None doesn't serialize
         if len(self.discard_pile) > 0:
             top_card = self.discard_pile[-1]
         return [top_card, len(self.discard_pile)]


### PR DESCRIPTION
Added "deck" to definition of card.  This should fix ambiguity between wrapped cards that occurred  when you picked up the pile (played cards, and pile contained "identical" cards in your hand, so they inherited status and position of cards just played).
Also now prints which round is currently being played in the lower right corner.