### PR TITLE
Add player between rounds

### DIFF
--- a/source/RunClient.py
+++ b/source/RunClient.py
@@ -35,6 +35,19 @@ def RunClient():
     createDisplay = CreateDisplay(playername)
     handView = HandView(gameControl, createDisplay.display)
     tableView = TableView(createDisplay.display)
+    while(len(tableView.player_names) < 1) or (tableView.player_names.count('guest') > 0 ):
+        note = "waiting for updated list of player names"
+        createDisplay.refresh()
+        handView.nextEvent()
+        connection.Pump()
+        gameControl.Pump()
+        tableView.Pump()
+        handView.update()
+        tableView.playerByPlayer()
+        note = "updating list of player names"
+        createDisplay.render(note)
+        sleep(0.001)
+    gameControl.checkNames(tableView.player_names)
     while True:
         createDisplay.refresh()
         handView.nextEvent()

--- a/source/RunClient.py
+++ b/source/RunClient.py
@@ -6,7 +6,7 @@ from client.Controller import Controller
 from client.CreateDisplay import CreateDisplay
 from client.HandView import HandView
 from client.TableView import TableView
-# imports below make it added so that can generate executable using pyinstaller.
+# imports below added so that can generate executable using pyinstaller.
 import common.HandAndFoot
 import common.Card
 import client.Button

--- a/source/client/Controller.py
+++ b/source/client/Controller.py
@@ -25,14 +25,15 @@ class Controller(ConnectionListener):
     ### Player Actions ###
     def setName(self):
         """Set up a display name and send it to the server"""
-        #TODO: get updated list of player names.
+        #TODO: replace next line with updated list of player names.
         self.player_names = ['asdf']
         displayName = input("Enter a display name: ")
         while displayName in self.player_names:
             name2 = "Bob" + str(random.randint(101, 999))
             print(displayName + ' already taken,' + 'you shall be named: ' + name2)
-            # it is possible that two players might still end up with the same name due to timing,
-            # but we do not yet deal with this corner case.
+            # todo: once this is debugged, then:
+            # it is possible (though unlikely) that two players might still end up with the
+            # same name due to timing, but we do not deal with this corner case.
             displayName = name2
         self._state.name = displayName
         connection.Send({"action": "displayName", "name": displayName})
@@ -256,6 +257,7 @@ class Controller(ConnectionListener):
     
     def Network_deal(self, data):
         self._state.round = data["round"]
+        print('debug --current round: '+str(self._state.round))
         self._state.reset()
         hand_list = [[Card.deserialize(c) for c in hand] for hand in data["hands"]]
         #TODO: we want to allow the player to choose the order of the hands eventually

--- a/source/client/Controller.py
+++ b/source/client/Controller.py
@@ -212,6 +212,11 @@ class Controller(ConnectionListener):
         status_info = self._state.getHandStatus()
         connection.Send({"action": "publicInfo", "visible_cards":serialized_cards, "hand_status":status_info})
 
+    def lateJoinScores(self, score):
+        """ When a player joins late the early rounds need to be assigned a score.  This does it. """
+        print('debug - controller line 217, score: ' + str(score))
+        connection.Send({"action": "reportScore", "score": score})
+
     #######################################
     ### Network event/message callbacks ###
     #######################################

--- a/source/client/Controller.py
+++ b/source/client/Controller.py
@@ -1,5 +1,5 @@
+import random                  # will be used to assign unique names
 from common.Card import Card
-
 from PodSixNet.Connection import connection, ConnectionListener
 
 Turn_Phases = ['inactive', 'draw', 'forcedAction', 'play']
@@ -18,13 +18,25 @@ class Controller(ConnectionListener):
         self.setName()
         self.ready = False
         self.note = "Game is beginning."
+        # TODO: figure out how to get player_names = current list of display names of all players
+        #  (TableView.player_names).
+        self.player_names = []
 
     ### Player Actions ###
     def setName(self):
         """Set up a display name and send it to the server"""
-        displayName = input("Select a display name: ")
+        #TODO: get updated list of player names.
+        self.player_names = ['asdf']
+        displayName = input("Enter a display name: ")
+        while displayName in self.player_names:
+            name2 = "Bob" + str(random.randint(101, 999))
+            print(displayName + ' already taken,' + 'you shall be named: ' + name2)
+            # it is possible that two players might still end up with the same name due to timing,
+            # but we do not yet deal with this corner case.
+            displayName = name2
         self._state.name = displayName
         connection.Send({"action": "displayName", "name": displayName})
+
 
     def setReady(self, readyState):
         """Update the player's ready state with the server"""

--- a/source/client/Controller.py
+++ b/source/client/Controller.py
@@ -257,7 +257,7 @@ class Controller(ConnectionListener):
     
     def Network_deal(self, data):
         self._state.round = data["round"]
-        print('debug --current round: '+str(self._state.round))
+        print('debug (line 260 in controller)--current round: '+str(self._state.round))
         self._state.reset()
         hand_list = [[Card.deserialize(c) for c in hand] for hand in data["hands"]]
         #TODO: we want to allow the player to choose the order of the hands eventually
@@ -275,6 +275,7 @@ class Controller(ConnectionListener):
         self.note = "{0} has gone out to end the round!".format(out_player)
         self._state.round = -1
         score = self._state.scoreRound()
+        print('debug - controller line 278, score: '+str(score))
         connection.Send({"action": "reportScore", "score": score})
         self.setReady(False)
 

--- a/source/client/HandAndFootButtons.py
+++ b/source/client/HandAndFootButtons.py
@@ -62,7 +62,7 @@ def ButtonDisplay(hand_view):
         hand_view.ready_yes_btn.draw(hand_view.display, hand_view.ready_yes_btn.outline_color)
         hand_view.ready_no_btn.draw(hand_view.display, hand_view.ready_no_btn.outline_color)
     else:
-        hand_view.labelMedium(str(Meld_Threshold[hand_view.next_round]) + "points to meld",
+        hand_view.labelMedium(str(Meld_Threshold[hand_view.controller._state.round]) + "points to meld",
                               hand_view.round_indicator_xy[0], hand_view.round_indicator_xy[1])
     hand_view.sort_status_btn.draw(hand_view.display, hand_view.sort_status_btn.outline_color)
     hand_view.sort_btn.draw(hand_view.display, hand_view.sort_btn.outline_color)

--- a/source/client/HandAndFootButtons.py
+++ b/source/client/HandAndFootButtons.py
@@ -62,7 +62,7 @@ def ButtonDisplay(hand_view):
         hand_view.ready_yes_btn.draw(hand_view.display, hand_view.ready_yes_btn.outline_color)
         hand_view.ready_no_btn.draw(hand_view.display, hand_view.ready_no_btn.outline_color)
     else:
-        hand_view.labelMedium(str(Meld_Threshold[hand_view.round_index]) + "points to meld",
+        hand_view.labelMedium(str(Meld_Threshold[hand_view.next_round]) + "points to meld",
                               hand_view.round_indicator_xy[0], hand_view.round_indicator_xy[1])
     hand_view.sort_status_btn.draw(hand_view.display, hand_view.sort_status_btn.outline_color)
     hand_view.sort_btn.draw(hand_view.display, hand_view.sort_btn.outline_color)

--- a/source/client/HandView.py
+++ b/source/client/HandView.py
@@ -39,11 +39,8 @@ class HandView:
         self.selected_list = []
         self.next_round = 0 # can only join in when self.controller._state.round = -1 :(  self.controller._state.round + 1
         print('debug in Handview line 41 --(self.next_round): '+str(self.next_round))
-        # todo: must report scores of zero to server for rounds missed
-        #   (could set rule so that it reports back average score for each round).
-        #  todo: Change [999999] back to None in PlayerChannel.
-        #  todo: Also  fix: -- first line of message is off round after round for the late player.
-        # todo: test, then remove all debug print statements.
+        # todo: report scores to server for rounds missed (for now report zero)
+        # todo: then remove all debug print statements.
         self.round_advance = False
         self.ready_color_idx = 2
         self.not_ready_color_idx = 6
@@ -69,7 +66,14 @@ class HandView:
                     self.betweenrounds = ['Game has concluded. Scores for each round can be found in command window.']
                 self.round_advance = False
         else:
-            self.next_round = self.controller._state.round # Need this to true up next_round if a player joins mid-game.
+            if not self.next_round == self.controller._state.round:
+                # Need this to true up next_round if a player joins mid-game.
+                skipped_rounds =  self.controller._state.round - self.next_round
+                print('debug: HV line 72, Missed ' + str(skipped_rounds) + ', assigning score = zero to those rounds')
+                for idx in range(skipped_rounds):
+                    score = 0
+                    self.controller.lateJoinScores(score)
+                self.next_round = self.controller._state.round
             self.round_advance = True
             # reset outline colors on ready buttons to what they need to be at the start of the "between rounds" state.
             self.ready_color_idx = 2

--- a/source/client/HandView.py
+++ b/source/client/HandView.py
@@ -58,6 +58,9 @@ class HandView:
             self.mesgBetweenRounds(self.betweenrounds)
             if self.round_advance:
                 self.next_round = self.next_round + 1
+                if self.next_round < self.controller._state.round:
+                    print('debug -- note, this didnot print even though I expected it to.') # need to update next_round when player joins in later round.
+                    hand_view.next_round = self._state.round
                 if self.next_round < len(Meld_Threshold):
                     self.betweenrounds[0] = 'This is the round of ' + str(Meld_Threshold[self.next_round]) + ' ! '
                 else:

--- a/source/client/HandView.py
+++ b/source/client/HandView.py
@@ -37,12 +37,13 @@ class HandView:
         self.num_wilds = 0
         self.wild_cards = []
         self.selected_list = []
-        self.round_index = 0
+        self.next_round = self.controller._state.round + 1
+        print('debug in Handview --current round: '+str(self.next_round))
         self.round_advance = False
         self.ready_color_idx = 2
         self.not_ready_color_idx = 6
         # --- Hand And Foot Specific:
-        self.betweenrounds = ['Welcome to a new game.  This is the round of ' + str(Meld_Threshold[0]) + '.',
+        self.betweenrounds = ['Welcome to a new game.  This is the round of ' + str(Meld_Threshold[self.next_round]) + '.',
                               'To draw click on the deck of cards (upper left).',
                               'To discard select ONE card & double click on discard button. ',
                               'To pick up pile PREPARE necessary cards & then click on discard pile. ',
@@ -56,9 +57,9 @@ class HandView:
         if self.controller._state.round == -1:
             self.mesgBetweenRounds(self.betweenrounds)
             if self.round_advance:
-                self.round_index = self.round_index + 1
-                if self.round_index < len(Meld_Threshold):
-                    self.betweenrounds[0] = 'This is the round of ' + str(Meld_Threshold[self.round_index]) + ' ! '
+                self.next_round = self.next_round + 1
+                if self.next_round < len(Meld_Threshold):
+                    self.betweenrounds[0] = 'This is the round of ' + str(Meld_Threshold[self.next_round]) + ' ! '
                 else:
                     self.betweenrounds = ['Game has concluded. Scores for each round can be found in command window.']
                 self.round_advance = False

--- a/source/client/HandView.py
+++ b/source/client/HandView.py
@@ -39,6 +39,11 @@ class HandView:
         self.selected_list = []
         self.next_round = 0 # can only join in when self.controller._state.round = -1 :(  self.controller._state.round + 1
         print('debug in Handview line 41 --(self.next_round): '+str(self.next_round))
+        # todo: must report scores of zero to server for rounds missed
+        #   (could set rule so that it reports back average score for each round).
+        #  todo: Change [999999] back to None in PlayerChannel.
+        #  todo: Also  fix: -- first line of message is off round after round for the late player.
+        # todo: test, then remove all debug print statements.
         self.round_advance = False
         self.ready_color_idx = 2
         self.not_ready_color_idx = 6
@@ -58,17 +63,13 @@ class HandView:
             self.mesgBetweenRounds(self.betweenrounds)
             if self.round_advance:
                 self.next_round = self.next_round + 1
-                # todo - delete following lines if they're never called
-                print('debug, HV line 62: self.next_round, self.controller._state.round:'+str(self.next_round)+' '+str(self.controller._state.round))
-                # if self.next_round < self.controller._state.round:
-                #    print('debug -- note, this didnot print even though I expected it to.') # need to update next_round when player joins in later round.
-                #    self.next_round = self.controller._state.round
                 if self.next_round < len(Meld_Threshold):
                     self.betweenrounds[0] = 'This is the round of ' + str(Meld_Threshold[self.next_round]) + ' ! '
                 else:
                     self.betweenrounds = ['Game has concluded. Scores for each round can be found in command window.']
                 self.round_advance = False
         else:
+            self.next_round = self.controller._state.round # Need this to true up next_round if a player joins mid-game.
             self.round_advance = True
             # reset outline colors on ready buttons to what they need to be at the start of the "between rounds" state.
             self.ready_color_idx = 2

--- a/source/client/HandView.py
+++ b/source/client/HandView.py
@@ -37,10 +37,7 @@ class HandView:
         self.num_wilds = 0
         self.wild_cards = []
         self.selected_list = []
-        self.next_round = 0 # can only join in when self.controller._state.round = -1 :(  self.controller._state.round + 1
-        print('debug in Handview line 41 --(self.next_round): '+str(self.next_round))
-        # todo: report scores to server for rounds missed (for now report zero)
-        # todo: then remove all debug print statements.
+        self.next_round = 0
         self.round_advance = False
         self.ready_color_idx = 2
         self.not_ready_color_idx = 6
@@ -69,7 +66,6 @@ class HandView:
             if not self.next_round == self.controller._state.round:
                 # Need this to true up next_round if a player joins mid-game.
                 skipped_rounds =  self.controller._state.round - self.next_round
-                print('debug: HV line 72, Missed ' + str(skipped_rounds) + ', assigning score = zero to those rounds')
                 for idx in range(skipped_rounds):
                     score = 0
                     self.controller.lateJoinScores(score)

--- a/source/client/HandView.py
+++ b/source/client/HandView.py
@@ -37,8 +37,8 @@ class HandView:
         self.num_wilds = 0
         self.wild_cards = []
         self.selected_list = []
-        self.next_round = self.controller._state.round + 1
-        print('debug in Handview --current round: '+str(self.next_round))
+        self.next_round = 0 # can only join in when self.controller._state.round = -1 :(  self.controller._state.round + 1
+        print('debug in Handview line 41 --(self.next_round): '+str(self.next_round))
         self.round_advance = False
         self.ready_color_idx = 2
         self.not_ready_color_idx = 6
@@ -58,9 +58,11 @@ class HandView:
             self.mesgBetweenRounds(self.betweenrounds)
             if self.round_advance:
                 self.next_round = self.next_round + 1
-                if self.next_round < self.controller._state.round:
-                    print('debug -- note, this didnot print even though I expected it to.') # need to update next_round when player joins in later round.
-                    hand_view.next_round = self._state.round
+                # todo - delete following lines if they're never called
+                print('debug, HV line 62: self.next_round, self.controller._state.round:'+str(self.next_round)+' '+str(self.controller._state.round))
+                # if self.next_round < self.controller._state.round:
+                #    print('debug -- note, this didnot print even though I expected it to.') # need to update next_round when player joins in later round.
+                #    self.next_round = self.controller._state.round
                 if self.next_round < len(Meld_Threshold):
                     self.betweenrounds[0] = 'This is the round of ' + str(Meld_Threshold[self.next_round]) + ' ! '
                 else:

--- a/source/client/TableView.py
+++ b/source/client/TableView.py
@@ -89,8 +89,12 @@ class TableView(ConnectionListener):
                     text_rect.center = ((bk_grd_rect[0] + 0.5 * players_sp_w), (bk_grd_rect[1] + ykey))
                     self.display.blit(text_surface, text_rect)
                 # Print cumulative score for this player.
+                # todo: If player just joined game then self.results[player_name] is null.  Need to catch that.
             if len(self.results) > 0:
-                player_total_points = str(self.results[player_name])
+                if self.results.get(player_name) is not None:
+                    player_total_points = str(self.results[player_name])
+                else:
+                    player_total_points = '---'
                 text_surface, text_rect = self.textObjects(player_total_points, UIC.Small_Text, UIC.Blue)
                 text_rect.center = (bk_grd_rect[0] + 0.5 * players_sp_w,
                                     bk_grd_rect[1] + y_coord + (UIC.Small_Text_Feed * 13))

--- a/source/client/TableView.py
+++ b/source/client/TableView.py
@@ -89,7 +89,7 @@ class TableView(ConnectionListener):
                     text_rect.center = ((bk_grd_rect[0] + 0.5 * players_sp_w), (bk_grd_rect[1] + ykey))
                     self.display.blit(text_surface, text_rect)
                 # Print cumulative score for this player.
-                # todo: If player just joined game then self.results[player_name] is null.  Need to catch that.
+                # If player just joined game then self.results[player_name] is null.  Need to catch that.
             if len(self.results) > 0:
                 if self.results.get(player_name) is not None:
                     player_total_points = str(self.results[player_name])

--- a/source/server/GameServer.py
+++ b/source/server/GameServer.py
@@ -21,8 +21,11 @@ class GameServer(Server, ServerState):
 
     def Connected(self, channel, addr):
         """Called by podsixnet when a client connects and establishes a channel"""
-        if self.round >= 0:
-            print(channel, 'Client tried to connect during active game')
+        #todo: remove this vestige: look to see if in round, instead of if have started rounds.
+        #todo: if self.round >= 0:
+        if self.in_round:
+            # todo: remove vestige print(channel, 'Client tried to connect during active game')
+            print(channel, 'Client tried to connect during active round, try again between rounds')
             channel.Send({"action": "connectionDenied"})
         else:
             self.players.append(channel)

--- a/source/server/GameServer.py
+++ b/source/server/GameServer.py
@@ -27,9 +27,15 @@ class GameServer(Server, ServerState):
             print(channel, 'Client tried to connect during active round, try again between rounds')
             channel.Send({"action": "connectionDenied"})
         else:
+            print('debug, at line 30 in GameServer')
             self.players.append(channel)
             self.Send_publicInfo()
             print(channel, "Client connected")
+            print(str(self.round))
+            if self.round >= 0:
+                print(channel, 'a client joined between rounds, give them scores of zero for rounds missed')
+                for round_idx in range(0, self.round):
+                    channel.scoreForRound = 0
 
     def disconnect(self, channel):
         """Called by a channel when it disconnects"""

--- a/source/server/GameServer.py
+++ b/source/server/GameServer.py
@@ -4,7 +4,6 @@ from server.ServerState import ServerState
 from PodSixNet.Server import Server
 from PodSixNet.Channel import Channel
 
-
 class GameServer(Server, ServerState):
     channelClass = PlayerChannel
 
@@ -21,7 +20,7 @@ class GameServer(Server, ServerState):
 
     def Connected(self, channel, addr):
         """Called by podsixnet when a client connects and establishes a channel"""
-        #todo: remove this vestige: look to see if in round, instead of if have started rounds.
+        #todo: remove vestige comment below: look to see if in round, instead of if have started rounds.
         #todo: if self.round >= 0:
         if self.in_round:
             # todo: remove vestige print(channel, 'Client tried to connect during active game')

--- a/source/server/GameServer.py
+++ b/source/server/GameServer.py
@@ -106,6 +106,10 @@ class GameServer(Server, ServerState):
         """Send the scores to all players"""
         round_scores = [p.scoreForRound(self.round) for p in self.players]
         total_scores = [sum(p.scores) for p in self.players]
+        print("debug - in GameServer:")
+        for p in self.players:
+            print('debug-round score: '+ str(p.scoreForRound(self.round)))
+            print('debug-total score:' + str(sum(p.scores)))
         if None not in round_scores:
             self.Send_broadcast({"action": "scores", "round_scores": round_scores, "total_scores": total_scores})
 

--- a/source/server/GameServer.py
+++ b/source/server/GameServer.py
@@ -20,22 +20,15 @@ class GameServer(Server, ServerState):
 
     def Connected(self, channel, addr):
         """Called by podsixnet when a client connects and establishes a channel"""
-        #todo: remove vestige comment below: look to see if in round, instead of if have started rounds.
-        #todo: if self.round >= 0:
         if self.in_round:
-            # todo: remove vestige print(channel, 'Client tried to connect during active game')
             print(channel, 'Client tried to connect during active round, try again between rounds')
             channel.Send({"action": "connectionDenied"})
         else:
-            print('debug, at line 30 in GameServer')
             self.players.append(channel)
             self.Send_publicInfo()
             print(channel, "Client connected")
-            print(str(self.round))
             if self.round >= 0:
-                print(channel, 'a client joined between rounds, give them scores of zero for rounds missed')
-                for round_idx in range(0, self.round):
-                    channel.scoreForRound = 0
+                print(channel, 'a client joined between rounds')
 
     def disconnect(self, channel):
         """Called by a channel when it disconnects"""
@@ -65,7 +58,6 @@ class GameServer(Server, ServerState):
         self.prepareRound(len(self.players))
         for player in self.players:
             player.Send_deal(self.dealHands(), self.round)
-        #set turn index to the dealer then start play
         self.turn_index = self.round
         self.nextTurn()
 
@@ -106,10 +98,6 @@ class GameServer(Server, ServerState):
         """Send the scores to all players"""
         round_scores = [p.scoreForRound(self.round) for p in self.players]
         total_scores = [sum(p.scores) for p in self.players]
-        print("debug - in GameServer:")
-        for p in self.players:
-            print('debug-round score: '+ str(p.scoreForRound(self.round)))
-            print('debug-total score:' + str(sum(p.scores)))
         if None not in round_scores:
             self.Send_broadcast({"action": "scores", "round_scores": round_scores, "total_scores": total_scores})
 

--- a/source/server/GameServer.py
+++ b/source/server/GameServer.py
@@ -71,7 +71,7 @@ class GameServer(Server, ServerState):
         """
         player_index = self.players.index(player)
         self.players.remove(player)
-        self.Send_publicInfo();
+        self.Send_publicInfo()
         #Check for no more players
         if len(self.players) == 0:
             self.game_over = True

--- a/source/server/PlayerChannel.py
+++ b/source/server/PlayerChannel.py
@@ -20,7 +20,7 @@ class PlayerChannel(Channel):
         """ Handles getting score for round so we don't error if this player hasn't reported yet."""
         try:
             print("debug: at line 22 in server\playerchannel.py, will print round, self.scores[round]")
-            print(str(round) + '     ' + str(self.scores[round]))
+            print(str(round) + '     ' + str(self.scores))
             return self.scores[round]
         except:
             # debug: return None

--- a/source/server/PlayerChannel.py
+++ b/source/server/PlayerChannel.py
@@ -19,9 +19,12 @@ class PlayerChannel(Channel):
     def scoreForRound(self, round):
         """Handles getting score for round so we don't error if this player hasn't reported yet"""
         try:
+            print("debug: at line 22 in server\playerchannel.py")
             return self.scores[round]
         except:
-            return None
+            # debug: return None
+            print("debug: at line 26 in server\playerchannel.py")
+            return [999999]
         
     def Close(self):
         """Called when a player disconnects
@@ -77,6 +80,8 @@ class PlayerChannel(Channel):
     ### Score reports ###
     def Network_reportScore(self, data):
         score = data["score"]
+        print("debug: at line 83 in server\playerchannel.py")
+        print("debug: " + str(score) +" " + self.name)
         self.scores.append(score)
         self._server.Send_scores()
         #Clear out visible cards since the round is over (This clear won't be broadcast until later)

--- a/source/server/PlayerChannel.py
+++ b/source/server/PlayerChannel.py
@@ -6,7 +6,7 @@ class PlayerChannel(Channel):
 
     def __init__(self, *args, **kwargs):
         """This overrides the lower lvl channel init
-        It's a place to set any client information thats provided from the server
+        It's a place to set any client information that's provided from the server
         """
         self.name = "guest"
         #visible cards and hand status are public info

--- a/source/server/PlayerChannel.py
+++ b/source/server/PlayerChannel.py
@@ -17,14 +17,15 @@ class PlayerChannel(Channel):
         Channel.__init__(self, *args, **kwargs)
 
     def scoreForRound(self, round):
-        """Handles getting score for round so we don't error if this player hasn't reported yet"""
+        """ Handles getting score for round so we don't error if this player hasn't reported yet."""
         try:
-            print("debug: at line 22 in server\playerchannel.py")
+            print("debug: at line 22 in server\playerchannel.py, will print round, self.scores[round]")
+            print(str(round) + '     ' + str(self.scores[round]))
             return self.scores[round]
         except:
             # debug: return None
             print("debug: at line 26 in server\playerchannel.py")
-            return [999999]
+            return None
         
     def Close(self):
         """Called when a player disconnects

--- a/source/server/PlayerChannel.py
+++ b/source/server/PlayerChannel.py
@@ -19,12 +19,8 @@ class PlayerChannel(Channel):
     def scoreForRound(self, round):
         """ Handles getting score for round so we don't error if this player hasn't reported yet."""
         try:
-            print("debug: at line 22 in server\playerchannel.py, will print round, self.scores[round]")
-            print(str(round) + '     ' + str(self.scores))
             return self.scores[round]
         except:
-            # debug: return None
-            print("debug: at line 26 in server\playerchannel.py")
             return None
         
     def Close(self):
@@ -81,8 +77,6 @@ class PlayerChannel(Channel):
     ### Score reports ###
     def Network_reportScore(self, data):
         score = data["score"]
-        print("debug: at line 83 in server\playerchannel.py")
-        print("debug: " + str(score) +" " + self.name)
         self.scores.append(score)
         self._server.Send_scores()
         #Clear out visible cards since the round is over (This clear won't be broadcast until later)


### PR DESCRIPTION
This was based on AddDecktoCardDefinition branch, so it is not backwards compatible with previous versions (due to change in definition of Card).  
Players can now join between rounds.  As implemented late joining players start with a score of 0 for each previous round.
Players also have names checked to insure that no two players have the same name.  Rather than have them choose a new name, this version assigns them one.   To implement this had to make 'guest' no longer a valid name (it's the name used until the users enters a displayname).  This was done by creating a list of forbidden names (list is currently ['guest'].
Testing has all been done on a single laptop, so network testing would be useful.